### PR TITLE
Add require for ipaddr

### DIFF
--- a/lib/rack/cloudflare.rb
+++ b/lib/rack/cloudflare.rb
@@ -1,4 +1,5 @@
 require "rack/cloudflare/version"
+require "ipaddr"
 
 module Rack
   module Cloudflare


### PR DESCRIPTION
Otherwise this gem seems to break on Rails 4.2, which I _guess_ removed their require for this stdlib library
